### PR TITLE
Correctly implement namespace

### DIFF
--- a/packages/semaforo-ui/src/hooks/useFlags.js
+++ b/packages/semaforo-ui/src/hooks/useFlags.js
@@ -3,7 +3,7 @@ import { DEFAULT_NAMESPACE } from '../index'
 
 function useFlags (namespace = DEFAULT_NAMESPACE) {
   const { user = {} } = useAuth0()
-  const flags = user[namespace] || {}
+  const flags = user[`${namespace}/flags`] || {}
   return flags
 }
 

--- a/packages/semaforo-ui/src/hooks/useFlags.test.js
+++ b/packages/semaforo-ui/src/hooks/useFlags.test.js
@@ -26,20 +26,20 @@ test('get the flags from the user with defaults', () => {
 })
 
 test('get the flags from the user using passed property name', () => {
-  const flagsProperty = 'http://test/flags'
+  const namespace = 'http://test'
   vi.mocked(useAuth0).mockReturnValue({
     user: {
       sub: '123',
       nickname: 'testuser',
       email: 'test@test.org',
-      [flagsProperty]: {
+      [`${namespace}/flags`]: {
         ff1: true,
         ff2: true
       }
     }
   })
 
-  const { result } = renderHook(() => useFlags(flagsProperty))
+  const { result } = renderHook(() => useFlags(namespace))
   expect(result.current).toEqual({
     ff1: true,
     ff2: true
@@ -47,7 +47,7 @@ test('get the flags from the user using passed property name', () => {
 })
 
 test('get the flags as empty object if there are no flags set on user', () => {
-  const namespace = 'http://test/flags'
+  const namespace = 'http://test'
   vi.mocked(useAuth0).mockReturnValue({
     user: {
       sub: '123',

--- a/packages/semaforo-ui/src/index.js
+++ b/packages/semaforo-ui/src/index.js
@@ -3,7 +3,7 @@ import EnableFeature from './EnableFeature'
 
 // This is the property name used to store the flags in the user object
 // Since Auth0 set them as custom claims, we are forced to apply a namespace
-const DEFAULT_NAMESPACE = 'https://platformatic.dev/flags'
+const DEFAULT_NAMESPACE = 'https://platformatic.dev'
 
 export {
   DEFAULT_NAMESPACE,


### PR DESCRIPTION
Previous version was assuming that the flags` part was in the namespace, (which is wrong).
This is fixed here.
